### PR TITLE
Updates the demo to work for API changes seen in Xcode 12 beta 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 The following project is a demo of a SwiftUI document-based app that stores it's document content in a JSON file.
 
+Note: SwiftUI is still a bit of a moving target. This demo works as of Xcode 12 beta 6.
+
 The problem we are modeling is how to migrate an ever changing document file schema over time.
 
 The solution we've come up with is the introduction of `PeopleDocumentFileRepresentation` which will own the serialization aspects of `PeopleDocument` to and from disk.

--- a/Shared/PeopleDocument.swift
+++ b/Shared/PeopleDocument.swift
@@ -14,23 +14,23 @@ struct PeopleDocument: FileDocument {
     init(people: [Person]) {
         self.people = people
     }
-
-    init(fileWrapper: FileWrapper, contentType: UTType) throws {
-        guard let data = fileWrapper.regularFileContents else {
+    
+    init(configuration: ReadConfiguration) throws {
+        guard let data = configuration.file.regularFileContents else {
             throw CocoaError(.fileReadCorruptFile)
         }
         let fileRep = try PeopleDocumentFileRepresentation(data: data)
         self.people = fileRep.people
     }
-    
-    func write(to fileWrapper: inout FileWrapper, contentType: UTType) throws {
+
+    func fileWrapper(configuration: WriteConfiguration) throws -> FileWrapper {
         do {
             let fileRep = PeopleDocumentFileRepresentation(people: self.people)
             // FIXME: Not sure if it's best to let a `DecodingError` error be thrown here,
             // but it does help debugging. Need to test how `FileDocument` will present
             // such an error.
             let fileRepData = try fileRep.data()
-            fileWrapper = FileWrapper(regularFileWithContents: fileRepData)
+            return .init(regularFileWithContents: fileRepData)
         } catch {
             throw CocoaError(.fileReadCorruptFile)
         }

--- a/Tests iOS/Fixtures/PeopleDocumentFileRepresentationFixtures.swift
+++ b/Tests iOS/Fixtures/PeopleDocumentFileRepresentationFixtures.swift
@@ -1,0 +1,27 @@
+import Foundation
+import SwiftUI
+import UniformTypeIdentifiers
+@testable import VersionedFilesDemo
+
+struct PeopleDocumentFileRepresentationFixtures {
+    
+    static var simpleV1: PeopleDocumentFileRepresentation {
+        return try! PeopleDocumentFileRepresentation(data: simple(version: 1))
+    }
+    
+    static var simpleV2: PeopleDocumentFileRepresentation {
+        return try! PeopleDocumentFileRepresentation(data: simple(version: 2))
+    }
+    
+    static var simpleV3: PeopleDocumentFileRepresentation {
+        return try! PeopleDocumentFileRepresentation(data: simple(version: 3))
+    }
+    
+    private static func simple(version: Int) -> Data {
+        let testBundle = Bundle(for: PeopleDocumentTests.self)
+        let filename = "simple-v\(version)"
+        let url = testBundle.url(forResource: filename, withExtension: "people")!
+        return try! Data(contentsOf: url)
+    }
+    
+}

--- a/Tests iOS/Fixtures/PeopleDocumentFixtures.swift
+++ b/Tests iOS/Fixtures/PeopleDocumentFixtures.swift
@@ -3,27 +3,29 @@ import SwiftUI
 import UniformTypeIdentifiers
 @testable import VersionedFilesDemo
 
+// These fixtures have been disabled until we can figure out how to instiate a new `PeopleDocument` using the updated API.
+// https://github.com/zorn/VersionedFilesDemo/issues/1
 struct PeopleDocumentFixtures {
     
-    static var simpleV1: PeopleDocument {
-        let configuration = PeopleDocument.ReadConfiguration(contentType: UTType.peopleDocumentType, file: simple(version: 1))
-        return try! PeopleDocument(configuration: configuration)
-    }
-    
-    static var simpleV2: PeopleDocument {
-        return try! PeopleDocument(fileWrapper: simple(version: 2), contentType: UTType.peopleDocumentType)
-    }
-    
-    static var simpleV3: PeopleDocument {
-        return try! PeopleDocument(fileWrapper: simple(version: 3), contentType: UTType.peopleDocumentType)
-    }
-    
-    private static func simple(version: Int) -> FileWrapper {
-        let testBundle = Bundle(for: PeopleDocumentTests.self)
-        let filename = "simple-v\(version)"
-        let url = testBundle.url(forResource: filename, withExtension: "people")!
-        let fileWrapper = try! FileWrapper(url: url)
-        return fileWrapper;
-    }
+//    static var simpleV1: PeopleDocument {
+//        let configuration = PeopleDocument.ReadConfiguration(contentType: UTType.peopleDocumentType, file: simple(version: 1))
+//        return try! PeopleDocument(configuration: configuration)
+//    }
+//    
+//    static var simpleV2: PeopleDocument {
+//        return try! PeopleDocument(fileWrapper: simple(version: 2), contentType: UTType.peopleDocumentType)
+//    }
+//    
+//    static var simpleV3: PeopleDocument {
+//        return try! PeopleDocument(fileWrapper: simple(version: 3), contentType: UTType.peopleDocumentType)
+//    }
+//    
+//    private static func simple(version: Int) -> FileWrapper {
+//        let testBundle = Bundle(for: PeopleDocumentTests.self)
+//        let filename = "simple-v\(version)"
+//        let url = testBundle.url(forResource: filename, withExtension: "people")!
+//        let fileWrapper = try! FileWrapper(url: url)
+//        return fileWrapper;
+//    }
     
 }

--- a/Tests iOS/Fixtures/PeopleDocumentFixtures.swift
+++ b/Tests iOS/Fixtures/PeopleDocumentFixtures.swift
@@ -1,11 +1,13 @@
 import Foundation
+import SwiftUI
 import UniformTypeIdentifiers
 @testable import VersionedFilesDemo
 
 struct PeopleDocumentFixtures {
     
     static var simpleV1: PeopleDocument {
-        return try! PeopleDocument(fileWrapper: simple(version: 1), contentType: UTType.peopleDocumentType)
+        let configuration = PeopleDocument.ReadConfiguration(contentType: UTType.peopleDocumentType, file: simple(version: 1))
+        return try! PeopleDocument(configuration: configuration)
     }
     
     static var simpleV2: PeopleDocument {

--- a/Tests iOS/Shared/PeopleDocumentFileRepresentationTests.swift
+++ b/Tests iOS/Shared/PeopleDocumentFileRepresentationTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+import UniformTypeIdentifiers
+@testable import VersionedFilesDemo
+
+class PeopleDocumentFileRepresentationTests: XCTestCase {
+
+    func test_peopleDocumentFileRepresentation_canSave_withTwoPeople() throws {
+        let fred = PersonFixture.new(["firstName": "Fred", "lastName": "Weasley", "birthday": Date.distantPast])
+        let george = PersonFixture.new(["firstName": "George", "lastName": "Weasley"])
+        let fileRep = PeopleDocumentFileRepresentation(people: [fred, george])
+        let data = try! fileRep.data()
+        let contents = String(data: data, encoding: .utf8)!
+        let expectedContents = """
+        {
+          "people" : [
+            {
+              "birthday" : "0001-01-01T00:00:00Z",
+              "first_name" : "Fred",
+              "id" : "\(fred.id.uuidString)",
+              "last_name" : "Weasley",
+              "mark_as_favorite" : false
+            },
+            {
+              "birthday" : null,
+              "first_name" : "George",
+              "id" : "\(george.id.uuidString)",
+              "last_name" : "Weasley",
+              "mark_as_favorite" : false
+            }
+          ],
+          "schema_version" : 3
+        }
+        """
+        XCTAssertEqual(contents, expectedContents)
+    }
+    
+    func test_peopleDocument_canOpen_withTwoPeople() throws {
+        let document = PeopleDocumentFileRepresentationFixtures.simpleV3
+        XCTAssertEqual(document.people.count, 2)
+        let fred = document.people[0]
+        XCTAssertEqual(fred.id.uuidString, "4E966EDD-893C-4F96-973A-949411B50149")
+        XCTAssertEqual(fred.firstName, "Fred")
+        XCTAssertEqual(fred.lastName, "Weasley")
+        XCTAssertEqual(fred.birthday, Date.distantPast)
+        XCTAssertEqual(fred.markAsFavorite, false)
+        
+        let george = document.people[1]
+        XCTAssertEqual(george.id.uuidString, "4545A339-A09F-4AEE-BE46-1C4FCF6466AA")
+        XCTAssertEqual(george.firstName, "George")
+        XCTAssertEqual(george.lastName, "Weasley")
+        XCTAssertEqual(george.birthday, nil)
+        XCTAssertEqual(george.markAsFavorite, false)
+    }
+    
+    func test_peopleDocument_canOpen_version1FileFormat() throws {
+        let document = PeopleDocumentFileRepresentationFixtures.simpleV1
+        XCTAssertEqual(document.people.count, 2)
+        let fred = document.people[0]
+        XCTAssertEqual(fred.id.uuidString, "4E966EDD-893C-4F96-973A-949411B50149")
+        XCTAssertEqual(fred.firstName, "Fred")
+        XCTAssertEqual(fred.lastName, "Weasley")
+        XCTAssertEqual(fred.birthday, nil)
+        XCTAssertEqual(fred.markAsFavorite, false)
+        
+        let george = document.people[1]
+        XCTAssertEqual(george.id.uuidString, "4545A339-A09F-4AEE-BE46-1C4FCF6466AA")
+        XCTAssertEqual(george.firstName, "George")
+        XCTAssertEqual(george.lastName, "Weasley")
+        XCTAssertEqual(george.birthday, nil)
+        XCTAssertEqual(george.markAsFavorite, false)
+    }
+
+}

--- a/Tests iOS/Shared/PeopleDocumentTests.swift
+++ b/Tests iOS/Shared/PeopleDocumentTests.swift
@@ -2,72 +2,74 @@ import XCTest
 import UniformTypeIdentifiers
 @testable import VersionedFilesDemo
 
+// These tests have been disabled until we can figure out how to instiate a new `PeopleDocument` using the updated API.
+// https://github.com/zorn/VersionedFilesDemo/issues/1
 class PeopleDocumentTests: XCTestCase {
     
-    func test_peopleDocument_canSave_withTwoPeople() throws {        
-        let fred = PersonFixture.new(["firstName": "Fred", "lastName": "Weasley", "birthday": Date.distantPast])
-        let george = PersonFixture.new(["firstName": "George", "lastName": "Weasley"])
-        let document = PeopleDocument(people: [fred, george])
-        var fileWrapper = FileWrapper(regularFileWithContents: Data())
-        try document.write(to: &fileWrapper, contentType: UTType.peopleDocumentType)
-        let contents = String(data: fileWrapper.regularFileContents!, encoding: .utf8)!
-        let expectedContents = """
-        {
-          "people" : [
-            {
-              "birthday" : "0001-01-01T00:00:00Z",
-              "first_name" : "Fred",
-              "id" : "\(fred.id.uuidString)",
-              "last_name" : "Weasley",
-              "mark_as_favorite" : false
-            },
-            {
-              "birthday" : null,
-              "first_name" : "George",
-              "id" : "\(george.id.uuidString)",
-              "last_name" : "Weasley",
-              "mark_as_favorite" : false
-            }
-          ],
-          "schema_version" : 3
-        }
-        """
-        XCTAssertEqual(contents, expectedContents)
-    }
-    
-    func test_peopleDocument_canOpen_withTwoPeople() throws {
-        let document = PeopleDocumentFixtures.simpleV3
-        XCTAssertEqual(document.people.count, 2)
-        let fred = document.people[0]
-        XCTAssertEqual(fred.id.uuidString, "4E966EDD-893C-4F96-973A-949411B50149")
-        XCTAssertEqual(fred.firstName, "Fred")
-        XCTAssertEqual(fred.lastName, "Weasley")
-        XCTAssertEqual(fred.birthday, Date.distantPast)
-        XCTAssertEqual(fred.markAsFavorite, false)
-        
-        let george = document.people[1]
-        XCTAssertEqual(george.id.uuidString, "4545A339-A09F-4AEE-BE46-1C4FCF6466AA")
-        XCTAssertEqual(george.firstName, "George")
-        XCTAssertEqual(george.lastName, "Weasley")
-        XCTAssertEqual(george.birthday, nil)
-        XCTAssertEqual(george.markAsFavorite, false)
-    }
-    
-    func test_peopleDocument_canOpen_version1FileFormat() throws {
-        let document = PeopleDocumentFixtures.simpleV1
-        XCTAssertEqual(document.people.count, 2)
-        let fred = document.people[0]
-        XCTAssertEqual(fred.id.uuidString, "4E966EDD-893C-4F96-973A-949411B50149")
-        XCTAssertEqual(fred.firstName, "Fred")
-        XCTAssertEqual(fred.lastName, "Weasley")
-        XCTAssertEqual(fred.birthday, nil)
-        XCTAssertEqual(fred.markAsFavorite, false)
-        
-        let george = document.people[1]
-        XCTAssertEqual(george.id.uuidString, "4545A339-A09F-4AEE-BE46-1C4FCF6466AA")
-        XCTAssertEqual(george.firstName, "George")
-        XCTAssertEqual(george.lastName, "Weasley")
-        XCTAssertEqual(george.birthday, nil)
-        XCTAssertEqual(george.markAsFavorite, false)
-    }
+//    func test_peopleDocument_canSave_withTwoPeople() throws {
+//        let fred = PersonFixture.new(["firstName": "Fred", "lastName": "Weasley", "birthday": Date.distantPast])
+//        let george = PersonFixture.new(["firstName": "George", "lastName": "Weasley"])
+//        let document = PeopleDocument(people: [fred, george])
+//        var fileWrapper = FileWrapper(regularFileWithContents: Data())
+//        try document.write(to: &fileWrapper, contentType: UTType.peopleDocumentType)
+//        let contents = String(data: fileWrapper.regularFileContents!, encoding: .utf8)!
+//        let expectedContents = """
+//        {
+//          "people" : [
+//            {
+//              "birthday" : "0001-01-01T00:00:00Z",
+//              "first_name" : "Fred",
+//              "id" : "\(fred.id.uuidString)",
+//              "last_name" : "Weasley",
+//              "mark_as_favorite" : false
+//            },
+//            {
+//              "birthday" : null,
+//              "first_name" : "George",
+//              "id" : "\(george.id.uuidString)",
+//              "last_name" : "Weasley",
+//              "mark_as_favorite" : false
+//            }
+//          ],
+//          "schema_version" : 3
+//        }
+//        """
+//        XCTAssertEqual(contents, expectedContents)
+//    }
+//
+//    func test_peopleDocument_canOpen_withTwoPeople() throws {
+//        let document = PeopleDocumentFixtures.simpleV3
+//        XCTAssertEqual(document.people.count, 2)
+//        let fred = document.people[0]
+//        XCTAssertEqual(fred.id.uuidString, "4E966EDD-893C-4F96-973A-949411B50149")
+//        XCTAssertEqual(fred.firstName, "Fred")
+//        XCTAssertEqual(fred.lastName, "Weasley")
+//        XCTAssertEqual(fred.birthday, Date.distantPast)
+//        XCTAssertEqual(fred.markAsFavorite, false)
+//
+//        let george = document.people[1]
+//        XCTAssertEqual(george.id.uuidString, "4545A339-A09F-4AEE-BE46-1C4FCF6466AA")
+//        XCTAssertEqual(george.firstName, "George")
+//        XCTAssertEqual(george.lastName, "Weasley")
+//        XCTAssertEqual(george.birthday, nil)
+//        XCTAssertEqual(george.markAsFavorite, false)
+//    }
+//
+//    func test_peopleDocument_canOpen_version1FileFormat() throws {
+//        let document = PeopleDocumentFixtures.simpleV1
+//        XCTAssertEqual(document.people.count, 2)
+//        let fred = document.people[0]
+//        XCTAssertEqual(fred.id.uuidString, "4E966EDD-893C-4F96-973A-949411B50149")
+//        XCTAssertEqual(fred.firstName, "Fred")
+//        XCTAssertEqual(fred.lastName, "Weasley")
+//        XCTAssertEqual(fred.birthday, nil)
+//        XCTAssertEqual(fred.markAsFavorite, false)
+//
+//        let george = document.people[1]
+//        XCTAssertEqual(george.id.uuidString, "4545A339-A09F-4AEE-BE46-1C4FCF6466AA")
+//        XCTAssertEqual(george.firstName, "George")
+//        XCTAssertEqual(george.lastName, "Weasley")
+//        XCTAssertEqual(george.birthday, nil)
+//        XCTAssertEqual(george.markAsFavorite, false)
+//    }
 }

--- a/VersionedFilesDemo.xcodeproj/project.pbxproj
+++ b/VersionedFilesDemo.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		1A639A6424E9B5FB007D3F9A /* MigrateV2ToV3swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A639A6324E9B5FB007D3F9A /* MigrateV2ToV3swift.swift */; };
 		1A639A6524E9B5FB007D3F9A /* MigrateV2ToV3swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A639A6324E9B5FB007D3F9A /* MigrateV2ToV3swift.swift */; };
 		1A639A6624E9B5FB007D3F9A /* MigrateV2ToV3swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A639A6324E9B5FB007D3F9A /* MigrateV2ToV3swift.swift */; };
+		1A6D783324FE85ED0059147D /* PeopleDocumentFileRepresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A6D783224FE85ED0059147D /* PeopleDocumentFileRepresentationTests.swift */; };
+		1A6D783524FE87460059147D /* PeopleDocumentFileRepresentationFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A6D783424FE87460059147D /* PeopleDocumentFileRepresentationFixtures.swift */; };
 		1A87B08824E86F4800F448E3 /* PeopleDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A87B08724E86F4800F448E3 /* PeopleDocumentTests.swift */; };
 		1AADEDAC24E8792C006DA24E /* PeopleDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A41E05A24E45A50007A7DEF /* PeopleDocument.swift */; };
 		1AADEDB024E87A11006DA24E /* simple-v1.people in Resources */ = {isa = PBXBuildFile; fileRef = 1AADEDAF24E87A11006DA24E /* simple-v1.people */; };
@@ -76,6 +78,8 @@
 		1A639A5924E98A91007D3F9A /* RawJSON.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = RawJSON.playground; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		1A639A5B24E9B0AC007D3F9A /* MigrateV1ToV2swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrateV1ToV2swift.swift; sourceTree = "<group>"; };
 		1A639A6324E9B5FB007D3F9A /* MigrateV2ToV3swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrateV2ToV3swift.swift; sourceTree = "<group>"; };
+		1A6D783224FE85ED0059147D /* PeopleDocumentFileRepresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleDocumentFileRepresentationTests.swift; sourceTree = "<group>"; };
+		1A6D783424FE87460059147D /* PeopleDocumentFileRepresentationFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleDocumentFileRepresentationFixtures.swift; sourceTree = "<group>"; };
 		1A87B07524E8613800F448E3 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		1A87B08724E86F4800F448E3 /* PeopleDocumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleDocumentTests.swift; sourceTree = "<group>"; };
 		1AADEDAF24E87A11006DA24E /* simple-v1.people */ = {isa = PBXFileReference; lastKnownFileType = text; path = "simple-v1.people"; sourceTree = "<group>"; };
@@ -204,6 +208,7 @@
 			isa = PBXGroup;
 			children = (
 				1A87B08724E86F4800F448E3 /* PeopleDocumentTests.swift */,
+				1A6D783224FE85ED0059147D /* PeopleDocumentFileRepresentationTests.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -254,6 +259,7 @@
 			isa = PBXGroup;
 			children = (
 				1AADEDBB24E88A76006DA24E /* PeopleDocumentFixtures.swift */,
+				1A6D783424FE87460059147D /* PeopleDocumentFileRepresentationFixtures.swift */,
 				1AADEDCF24E979E1006DA24E /* PersonFixture.swift */,
 			);
 			path = Fixtures;
@@ -453,9 +459,11 @@
 				1AADEDCE24E97898006DA24E /* Person.swift in Sources */,
 				1A87B08824E86F4800F448E3 /* PeopleDocumentTests.swift in Sources */,
 				1A639A6624E9B5FB007D3F9A /* MigrateV2ToV3swift.swift in Sources */,
+				1A6D783524FE87460059147D /* PeopleDocumentFileRepresentationFixtures.swift in Sources */,
 				1AADEDB224E883E3006DA24E /* PeopleDocumentFileRepresentation.swift in Sources */,
 				1AADEDBC24E88A76006DA24E /* PeopleDocumentFixtures.swift in Sources */,
 				1AADEDD024E979E1006DA24E /* PersonFixture.swift in Sources */,
+				1A6D783324FE85ED0059147D /* PeopleDocumentFileRepresentationTests.swift in Sources */,
 				1AADEDAC24E8792C006DA24E /* PeopleDocument.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
Specifically the `FileDocument` protocol was changed.

Getting the app code updates was easy but I still don't know how to use this new API inside a unit test. See issue #1 for info.

For now, I've reorganized the tests around the `PeopleDocumentFileRepresentation` type.